### PR TITLE
Send mobile Chrome and Firefox installs to extension stores

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -76,26 +76,19 @@ class InstallButton extends React.Component {
     // redirect away from the page.
     await downloadButtonClick()
 
-    if (this.state.mobile) {
-      console.info(
-        'Cannot add Tab for a Cause extension: this is a mobile device'
-      )
-      onUnsupportedBrowserInstallClick()
-    } else {
-      switch (this.state.browser) {
-        case CHROME_BROWSER:
-          this.installChromeExtension()
-          break
-        case FIREFOX_BROWSER:
-          this.installFirefoxExtension()
-          break
-        default:
-          console.info(
-            'Cannot add Tab for a Cause extension: this browser is not supported'
-          )
-          onUnsupportedBrowserInstallClick()
-          break
-      }
+    switch (this.state.browser) {
+      case CHROME_BROWSER:
+        this.installChromeExtension()
+        break
+      case FIREFOX_BROWSER:
+        this.installFirefoxExtension()
+        break
+      default:
+        console.info(
+          'Cannot add Tab for a Cause extension: this browser is not supported'
+        )
+        onUnsupportedBrowserInstallClick()
+        break
     }
   }
 

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -43,6 +43,9 @@ class InstallButton extends React.Component {
       case 'chromium':
         browser = CHROME_BROWSER
         break
+      case 'crios':
+        browser = CHROME_BROWSER
+        break
       case 'firefox':
         browser = FIREFOX_BROWSER
         break

--- a/src/components/__tests__/InstallButton.test.js
+++ b/src/components/__tests__/InstallButton.test.js
@@ -142,7 +142,7 @@ describe('InstallButton', () => {
     expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
   })
 
-  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with an unsupported desktop browser', async () => {
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Safari desktop browser', async () => {
     expect.assertions(1)
 
     const detectBrowser = require('browser-detect').default
@@ -159,7 +159,46 @@ describe('InstallButton', () => {
       />
     )
     await clickButton(wrapper)
+    expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
+  })
 
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Opera desktop browser', async () => {
+    expect.assertions(1)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('opera', false))
+
+    // Silence expected console.info log
+    jest.spyOn(console, 'info').mockImplementationOnce(() => {})
+
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const InstallButton = require('../InstallButton').default
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
+    expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
+  })
+
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Edge desktop browser', async () => {
+    expect.assertions(1)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('edge', false))
+
+    // Silence expected console.info log
+    jest.spyOn(console, 'info').mockImplementationOnce(() => {})
+
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const InstallButton = require('../InstallButton').default
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
     expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
   })
 
@@ -226,7 +265,7 @@ describe('InstallButton', () => {
     expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
   })
 
-  it('calls the onUnsupportedBrowserInstallClick prop when the user is on an unsupported browser (on mobile)', async () => {
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Safari mobile browser', async () => {
     expect.assertions(1)
 
     const detectBrowser = require('browser-detect').default
@@ -243,7 +282,46 @@ describe('InstallButton', () => {
       />
     )
     await clickButton(wrapper)
+    expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
+  })
 
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Opera mobile browser', async () => {
+    expect.assertions(1)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('opera', true))
+
+    // Silence expected console.info log
+    jest.spyOn(console, 'info').mockImplementationOnce(() => {})
+
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const InstallButton = require('../InstallButton').default
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
+    expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
+  })
+
+  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with the Edge mobile browser', async () => {
+    expect.assertions(1)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('edge', true))
+
+    // Silence expected console.info log
+    jest.spyOn(console, 'info').mockImplementationOnce(() => {})
+
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const InstallButton = require('../InstallButton').default
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
     expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
   })
 

--- a/src/components/__tests__/InstallButton.test.js
+++ b/src/components/__tests__/InstallButton.test.js
@@ -205,6 +205,27 @@ describe('InstallButton', () => {
     expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
   })
 
+  it('navigates to the Chrome Web Store page on click (on Chrome iOS browser)', async () => {
+    expect.assertions(2)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('crios', true))
+    const redirect = require('utils/redirect').default
+
+    const InstallButton = require('../InstallButton').default
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
+    expect(redirect).toHaveBeenCalledWith(
+      'https://chrome.google.com/webstore/detail/tab-for-a-cause/gibkoahgjfhphbmeiphbcnhehbfdlcgo'
+    )
+    expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
+  })
+
   it('calls the onUnsupportedBrowserInstallClick prop when the user is on an unsupported browser (on mobile)', async () => {
     expect.assertions(1)
 

--- a/src/components/__tests__/InstallButton.test.js
+++ b/src/components/__tests__/InstallButton.test.js
@@ -101,36 +101,45 @@ describe('InstallButton', () => {
   })
 
   it('navigates to the Firefox Addons page on click (on Firefox desktop browser)', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const detectBrowser = require('browser-detect').default
     detectBrowser.mockReturnValueOnce(createMockBrowserInfo('firefox', false))
     const redirect = require('utils/redirect').default
 
     const InstallButton = require('../InstallButton').default
-    const wrapper = mount(<InstallButton />)
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
     await clickButton(wrapper)
     expect(redirect).toHaveBeenCalledWith(
       'https://addons.mozilla.org/en-US/firefox/addon/tab-for-a-cause/'
     )
+    expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
   })
 
   it('navigates to the Chrome Web Store page on click (on Chrome desktop browser)', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const detectBrowser = require('browser-detect').default
     detectBrowser.mockReturnValueOnce(createMockBrowserInfo('chrome', false))
     const redirect = require('utils/redirect').default
 
     const InstallButton = require('../InstallButton').default
-    const mockOnChromeInstallBegin = jest.fn()
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
     const wrapper = mount(
-      <InstallButton onChromeInstallBegin={mockOnChromeInstallBegin} />
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
     )
     await clickButton(wrapper)
     expect(redirect).toHaveBeenCalledWith(
       'https://chrome.google.com/webstore/detail/tab-for-a-cause/gibkoahgjfhphbmeiphbcnhehbfdlcgo'
     )
+    expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
   })
 
   it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install with an unsupported desktop browser', async () => {
@@ -154,11 +163,53 @@ describe('InstallButton', () => {
     expect(mockOnUnsupportedBrowserInstallClick).toHaveBeenCalled()
   })
 
-  it('calls the onUnsupportedBrowserInstallClick prop when the user tries to install on mobile', async () => {
-    expect.assertions(1)
+  it('navigates to the Firefox Addons page on click (on Firefox mobile browser)', async () => {
+    expect.assertions(2)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('firefox', true))
+    const redirect = require('utils/redirect').default
+
+    const InstallButton = require('../InstallButton').default
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
+    expect(redirect).toHaveBeenCalledWith(
+      'https://addons.mozilla.org/en-US/firefox/addon/tab-for-a-cause/'
+    )
+    expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
+  })
+
+  it('navigates to the Chrome Web Store page on click (on Chrome mobile browser)', async () => {
+    expect.assertions(2)
 
     const detectBrowser = require('browser-detect').default
     detectBrowser.mockReturnValueOnce(createMockBrowserInfo('chrome', true))
+    const redirect = require('utils/redirect').default
+
+    const InstallButton = require('../InstallButton').default
+    const mockOnUnsupportedBrowserInstallClick = jest.fn()
+    const wrapper = mount(
+      <InstallButton
+        onUnsupportedBrowserInstallClick={mockOnUnsupportedBrowserInstallClick}
+      />
+    )
+    await clickButton(wrapper)
+    expect(redirect).toHaveBeenCalledWith(
+      'https://chrome.google.com/webstore/detail/tab-for-a-cause/gibkoahgjfhphbmeiphbcnhehbfdlcgo'
+    )
+    expect(mockOnUnsupportedBrowserInstallClick).not.toHaveBeenCalled()
+  })
+
+  it('calls the onUnsupportedBrowserInstallClick prop when the user is on an unsupported browser (on mobile)', async () => {
+    expect.assertions(1)
+
+    const detectBrowser = require('browser-detect').default
+    detectBrowser.mockReturnValueOnce(createMockBrowserInfo('safari', true))
 
     // Silence expected console.info log
     jest.spyOn(console, 'info').mockImplementationOnce(() => {})
@@ -181,10 +232,7 @@ describe('InstallButton', () => {
     const downloadButtonClick = require('utils/analytics/logEvent')
       .downloadButtonClick
     const InstallButton = require('../InstallButton').default
-    const mockOnChromeInstallBegin = jest.fn()
-    const wrapper = mount(
-      <InstallButton onChromeInstallBegin={mockOnChromeInstallBegin} />
-    )
+    const wrapper = mount(<InstallButton />)
     await clickButton(wrapper)
     expect(downloadButtonClick).toHaveBeenCalled()
   })


### PR DESCRIPTION
This is a better UX than the "unsupported browser" modal.