### PR TITLE
Adding Required Wave Color to Team Seas Landing

### DIFF
--- a/src/components/TeamSeas.Install.js
+++ b/src/components/TeamSeas.Install.js
@@ -213,11 +213,11 @@ const Seas = ({ pageContext, location }) => {
           <img src={headerImg}></img>
         </div>
         <div className={cx.wave}>
-          <Wave />
+          <Wave color={'#5094FB'} />
         </div>
       </div>
       <div className={cx.waveMobile}>
-        <Wave />
+        <Wave color={'#5094FB'} />
       </div>
       <UnsupportedBrowserDialog
         open={showUnsupportedBrowserMessage}


### PR DESCRIPTION
This resolves some errors when you run `yarn test` and such. Also it's a required prop so the lack of this should be throwing in the console too.