### PR TITLE
Fix #417: Add causeId to mobile app redirect URL

### DIFF
--- a/src/components/UnsupportedBrowserDialog.js
+++ b/src/components/UnsupportedBrowserDialog.js
@@ -12,6 +12,8 @@ import AppleIcon from '@mui/icons-material/Apple'
 import AndroidIcon from '@mui/icons-material/Android'
 import { buildMobileAppRedirectURL } from 'src/utils/navigation'
 import { getUrlParameterValue } from 'src/utils/location'
+import localStorageMgr from 'src/utils/local-storage'
+import { STORAGE_NEW_USER_CAUSE_ID } from 'src/utils/constants'
 
 const StoreButton = styled(Button)(({ theme }) => ({
   margin: theme.spacing(1),
@@ -61,8 +63,11 @@ class UnsupportedBrowserDialog extends React.Component {
       r = this.props.pageContext.referrer.id
     }
 
-    // Build and redirect to mobile app URL with campaign parameters
-    const redirectUrl = buildMobileAppRedirectURL(r, u, m)
+    // Get causeId from localStorage if it exists
+    const causeId = localStorageMgr.getItem(STORAGE_NEW_USER_CAUSE_ID) || ''
+
+    // Build and redirect to mobile app URL with campaign parameters including causeId
+    const redirectUrl = buildMobileAppRedirectURL(r, u, m, causeId)
     window.location.href = redirectUrl
   }
 

--- a/src/utils/__tests__/navigation.test.js
+++ b/src/utils/__tests__/navigation.test.js
@@ -67,29 +67,53 @@ describe('navigation utils', () => {
 
   test('buildMobileAppRedirectURL builds correct URL with all parameters', () => {
     const { buildMobileAppRedirectURL } = require('../navigation')
-    expect(buildMobileAppRedirectURL('abc123', 'user456', 'campaign789')).toBe(
-      'https://azy26.app.link?campaign=r%3Aabc123%3Au%3Auser456%3Am%3Acampaign789'
+    expect(
+      buildMobileAppRedirectURL('abc123', 'user456', 'campaign789', 'CA6A5C2uj')
+    ).toBe(
+      'https://azy26.app.link?campaign=r%3Aabc123%3Au%3Auser456%3Am%3Acampaign789%3Ac%3ACA6A5C2uj'
     )
   })
 
   test('buildMobileAppRedirectURL builds correct URL with empty parameters', () => {
     const { buildMobileAppRedirectURL } = require('../navigation')
-    expect(buildMobileAppRedirectURL('', '', '')).toBe(
-      'https://azy26.app.link?campaign=r%3A%3Au%3A%3Am%3A'
+    expect(buildMobileAppRedirectURL('', '', '', '')).toBe(
+      'https://azy26.app.link?campaign=r%3A%3Au%3A%3Am%3A%3Ac%3A'
     )
   })
 
   test('buildMobileAppRedirectURL builds correct URL with no parameters', () => {
     const { buildMobileAppRedirectURL } = require('../navigation')
     expect(buildMobileAppRedirectURL()).toBe(
-      'https://azy26.app.link?campaign=r%3A%3Au%3A%3Am%3A'
+      'https://azy26.app.link?campaign=r%3A%3Au%3A%3Am%3A%3Ac%3A'
     )
   })
 
   test('buildMobileAppRedirectURL builds correct URL with partial parameters', () => {
     const { buildMobileAppRedirectURL } = require('../navigation')
-    expect(buildMobileAppRedirectURL('ref123', '', 'camp456')).toBe(
-      'https://azy26.app.link?campaign=r%3Aref123%3Au%3A%3Am%3Acamp456'
+    expect(buildMobileAppRedirectURL('ref123', '', 'camp456', '')).toBe(
+      'https://azy26.app.link?campaign=r%3Aref123%3Au%3A%3Am%3Acamp456%3Ac%3A'
+    )
+  })
+
+  test('buildMobileAppRedirectURL builds correct URL with only causeId', () => {
+    const { buildMobileAppRedirectURL } = require('../navigation')
+    expect(buildMobileAppRedirectURL('', '', '', 'CA6A5C2uj')).toBe(
+      'https://azy26.app.link?campaign=r%3A%3Au%3A%3Am%3A%3Ac%3ACA6A5C2uj'
+    )
+  })
+
+  test('buildMobileAppRedirectURL builds correct URL with causeId and referrer only', () => {
+    const { buildMobileAppRedirectURL } = require('../navigation')
+    expect(buildMobileAppRedirectURL('ref123', '', '', 'SGa6zohkY')).toBe(
+      'https://azy26.app.link?campaign=r%3Aref123%3Au%3A%3Am%3A%3Ac%3ASGa6zohkY'
+    )
+  })
+
+  test('buildMobileAppRedirectURL maintains backward compatibility with 3 params', () => {
+    const { buildMobileAppRedirectURL } = require('../navigation')
+    // When called with only 3 params, causeId should be empty
+    expect(buildMobileAppRedirectURL('abc123', 'user456', 'campaign789')).toBe(
+      'https://azy26.app.link?campaign=r%3Aabc123%3Au%3Auser456%3Am%3Acampaign789%3Ac%3A'
     )
   })
 })

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -138,11 +138,12 @@ export const getAbsoluteURL = (path) => {
  * @param {string} r - The referrer parameter
  * @param {string} u - The user parameter
  * @param {string} m - The campaign parameter
+ * @param {string} c - The causeId parameter
  * @return {string} The mobile app redirect URL with campaign parameters
  */
-export const buildMobileAppRedirectURL = (r = '', u = '', m = '') => {
-  // Build campaign parameter in format r:{string}:u:{string}:m:{string}
-  const campaignParam = `r:${r}:u:${u}:m:${m}`
+export const buildMobileAppRedirectURL = (r = '', u = '', m = '', c = '') => {
+  // Build campaign parameter in format r:{string}:u:{string}:m:{string}:c:{string}
+  const campaignParam = `r:${r}:u:${u}:m:${m}:c:${c}`
   return `${MOBILE_APP_REDIRECT_URL}?campaign=${encodeURIComponent(
     campaignParam
   )}`


### PR DESCRIPTION
## Summary
This PR adds the `causeId` to the mobile app redirect URL so that when users on mobile devices visit cause-specific pages (like `/cats`) and try to install the extension, their cause preference is preserved when redirecting to the mobile app.

Fixes #417 

## Changes
- Updated `buildMobileAppRedirectURL` to accept and include `causeId` parameter in the campaign string
- Modified `UnsupportedBrowserDialog` to retrieve `causeId` from localStorage and pass it to the redirect URL
- Added comprehensive test coverage for all causeId scenarios
- Maintained backward compatibility for existing calls without the causeId parameter

## Technical Details
The redirect URL now uses the format: `r:{referrer}:u:{user}:m:{mission}:c:{causeId}`

### Edge Cases Handled
✅ CauseId exists but no referrer info (e.g., `r::u::m::c:CA6A5C2uj`)
✅ No causeId in localStorage (e.g., `r:abc:u:123:m:xyz:c:`)
✅ All parameters empty (e.g., `r::u::m::c:`)
✅ Backward compatibility when causeId not provided to function

## Test Plan
- [x] Unit tests pass for all new scenarios
- [x] Existing tests still pass
- [x] Backward compatibility maintained
- [ ] Test on mobile device visiting `/cats` page
- [ ] Verify mobile app correctly parses new format
- [ ] Test with and without referrer parameters

## Screenshots
N/A - Backend logic change

## Review Checklist
- [ ] Code follows project conventions
- [ ] Tests cover all edge cases
- [ ] No breaking changes to existing functionality
- [ ] Mobile app team aware of new parameter format